### PR TITLE
Fix typo: "subject the" -> "subject to"

Fix typo: "subject the" to "subject to" (#45)

### DIFF
--- a/src/guide/typescript/options-api.md
+++ b/src/guide/typescript/options-api.md
@@ -286,7 +286,7 @@ declare module 'vue' {
 
 Now the `beforeRouteEnter` option will be properly typed. Note this is just an example - well-typed libraries like `vue-router` should automatically perform these augmentations in their own type definitions.
 
-The placement of this augmentation is subject the [same restrictions](#type-augmentation-placement) as global property augmentations.
+The placement of this augmentation is subject to the [same restrictions](#type-augmentation-placement) as global property augmentations.
 
 See also:
 


### PR DESCRIPTION
resolves #45
Cherry picked from https://github.com/vuejs/docs/commit/cdddfa902799a6011aa1ee9a430e0de670ada64d