### PR TITLE
Update custom-directives.md

Removing `prevVnode` params from hooks where they aren't available. (#47)

### DIFF
--- a/src/guide/reusability/custom-directives.md
+++ b/src/guide/reusability/custom-directives.md
@@ -111,23 +111,23 @@ A directive definition object can provide several hook functions (all optional):
 const myDirective = {
   // called before bound element's attributes
   // or event listeners are applied
-  created(el, binding, vnode, prevVnode) {
+  created(el, binding, vnode) {
     // see below for details on arguments
   },
   // called right before the element is inserted into the DOM.
-  beforeMount(el, binding, vnode, prevVnode) {},
+  beforeMount(el, binding, vnode) {},
   // called when the bound element's parent component
   // and all its children are mounted.
-  mounted(el, binding, vnode, prevVnode) {},
+  mounted(el, binding, vnode) {},
   // called before the parent component is updated
   beforeUpdate(el, binding, vnode, prevVnode) {},
   // called after the parent component and
   // all of its children have updated
   updated(el, binding, vnode, prevVnode) {},
   // called before the parent component is unmounted
-  beforeUnmount(el, binding, vnode, prevVnode) {},
+  beforeUnmount(el, binding, vnode) {},
   // called when the parent component is unmounted
-  unmounted(el, binding, vnode, prevVnode) {}
+  unmounted(el, binding, vnode) {}
 }
 ```
 

--- a/src/guide/typescript/options-api.md
+++ b/src/guide/typescript/options-api.md
@@ -286,7 +286,7 @@ declare module 'vue' {
 
 Now the `beforeRouteEnter` option will be properly typed. Note this is just an example - well-typed libraries like `vue-router` should automatically perform these augmentations in their own type definitions.
 
-The placement of this augmentation is subject the [same restrictions](#type-augmentation-placement) as global property augmentations.
+The placement of this augmentation is subject to the [same restrictions](#type-augmentation-placement) as global property augmentations.
 
 See also:
 


### PR DESCRIPTION
resolves #47
Cherry picked from https://github.com/vuejs/docs/commit/7bb9835510e575299d953b3b6ca752d2f2377c9d