### PR TITLE
docs: add explanation for template-refs defineExpose before await

* docs: template-refs defineExpose before await

* Update src/guide/essentials/template-refs.md

---------

Co-authored-by: Natalia Tepluhina <tarya.se@gmail.com> (#89)

### DIFF
--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -237,6 +237,8 @@ defineExpose({
 
 When a parent gets an instance of this component via template refs, the retrieved instance will be of the shape `{ a: number, b: number }` (refs are automatically unwrapped just like on normal instances).
 
+Note that defineExpose must be called before any await operation. Otherwise, properties and methods exposed after the await operation will not be accessible. 
+
 See also: [Typing Component Template Refs](/guide/typescript/composition-api#typing-component-template-refs) <sup class="vt-badge ts" />
 
 </div>


### PR DESCRIPTION
resolves #89
Cherry picked from https://github.com/vuejs/docs/commit/dd5e8c8f0807538dc7e62e5f93cc5646480cb86e