### PR TITLE
docs: add missing "the" (#104)

### DIFF
--- a/src/api/general.md
+++ b/src/api/general.md
@@ -131,7 +131,7 @@ A type helper for defining a Vue component with type inference.
 
   ### Function Signature <sup class="vt-badge" data-text="3.3+" /> {#function-signature}
 
-  `defineComponent()` also has an alternative signature that is meant to be used with Composition API and [render functions or JSX](/guide/extras/render-function.html).
+  `defineComponent()` also has an alternative signature that is meant to be used with the Composition API and [render functions or JSX](/guide/extras/render-function.html).
 
   Instead of passing in an options object, a function is expected instead. This function works the same as the Composition API [`setup()`](/api/composition-api-setup.html#composition-api-setup) function: it receives the props and the setup context. The return value should be a render function - both `h()` and JSX are supported:
 


### PR DESCRIPTION
resolves #104
Cherry picked from https://github.com/vuejs/docs/commit/669f8721b43e6a89bf17524ae6a4f451a139d501