### PR TITLE
docs: clarify that :style can coexist with regular style attributes like class

* docs: clarify that :style can coexist with regular style attributes like class

* docs: clarify that :style can coexist with regular style attributes like class (#155)

### DIFF
--- a/src/guide/essentials/class-and-style.md
+++ b/src/guide/essentials/class-and-style.md
@@ -323,6 +323,20 @@ data() {
 
 Again, object style binding is often used in conjunction with computed properties that return objects.
 
+`:style` directives can also coexist with regular style attributes, just like `:class`.
+
+Template:
+
+```vue-html
+<h1 style="color: red" :style="'font-size: 1em'">hello</h1>
+```
+
+It will render:
+
+```vue-html
+<h1 style="color: red; font-size: 1em;">hello</h1>
+```
+
 ### Binding to Arrays {#binding-to-arrays-1}
 
 We can bind `:style` to an array of multiple style objects. These objects will be merged and applied to the same element:


### PR DESCRIPTION
resolves #155
Cherry picked from https://github.com/vuejs/docs/commit/2b7d5e0a96ea05c9370c747750d0efd0dcb93a74